### PR TITLE
Allow option to disable automatic reading of the default file. 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,6 @@ setup(name='supersettings',
       author='Greg Doermann',
       author_email='gdoermann@gmail.com',
       url='https://github.com/gdoermann/supersettings',
-      py_modules = ['supersettings', ]
-)
+      py_modules=['supersettings', ],
+      install_requires=['configparser'],
+      )

--- a/supersettings.py
+++ b/supersettings.py
@@ -21,7 +21,10 @@ import traceback
 from collections import OrderedDict
 import six
 
-from backports import configparser
+if six.PY2:
+    from backports import configparser
+else:
+    import configparser
 from backports.configparser import NoOptionError, InterpolationSyntaxError, InterpolationDepthError, \
     MAX_INTERPOLATION_DEPTH, NoSectionError, InterpolationMissingOptionError, from_none, _UNSET
 

--- a/supersettings.py
+++ b/supersettings.py
@@ -235,7 +235,7 @@ class MultiFileConfigParser(configparser.ConfigParser):
         return ((option, value_getter(option)) for option in d.keys())
 
 
-    def getenv(self, section, option, key=None, type=str):
+    def getenv(self, section, option, key=None, type=str, context=None):
         """
         Try and get the option out of os.enviorn and cast it, otherwise return the default (casted)
         :param section: settings section name
@@ -247,8 +247,12 @@ class MultiFileConfigParser(configparser.ConfigParser):
         if key is None:
             key = option
         value = os.environ.get(key, None)
-        try:
+
+        if value is not None:
+            try:
+                return type(value)
+            except TypeError:
+                pass
+        value = self.get(section, option, context=context)
+        if value:
             return type(value)
-        except TypeError:
-            pass
-        return type(self.get(section, option))

--- a/supersettings.py
+++ b/supersettings.py
@@ -22,7 +22,6 @@ import logging
 import re
 import traceback
 
-
 log = logging.getLogger(__name__)
 
 SECTION_REGEX = re.compile('%\((\w+):(\w+)\)s')
@@ -38,8 +37,6 @@ def resolve_string(str, context=None):
             name = str[1:]
             return context[name]
     return str
-
-
 
 
 class AttrDict(dict):
@@ -132,8 +129,7 @@ class MultiFileConfigParser(configparser.ConfigParser):
                 key_formatter=lambda k, c: resolve_string(str(k).upper()))
         )
 
-    def items(self, section=configparser._UNSET, raw=False, vars=None, context=None, key_formatter=None,
-              value_formatter=None):
+    def items(self, section, raw=False, vars=None, context=None, key_formatter=None, value_formatter=None):
         key_formatter = key_formatter or resolve_string
         value_formatter = value_formatter or resolve_string
         items = super(MultiFileConfigParser, self).items(section, raw, vars)

--- a/supersettings.py
+++ b/supersettings.py
@@ -64,7 +64,7 @@ class MultiFileConfigParser(configparser.ConfigParser):
     def __init__(self, file_name, default_file=None, auto_read=True, *args, **kwargs):
         self.file_name = file_name
         self.default_file = default_file
-        super(configparser.ConfigParser, self).__init__(*args, **kwargs)
+        super(MultiFileConfigParser, self).__init__(*args, **kwargs)
         self.config_files = []
         if auto_read:
             self.read_configs()

--- a/supersettings.py
+++ b/supersettings.py
@@ -99,7 +99,7 @@ class SuperInterpolator(configparser.ExtendedInterpolation):
                     raise from_none(InterpolationMissingOptionError(
                         option, section, rawval, ":".join(path)))
 
-                if "$" in v:
+                if v and "$" in v:
                     self._interpolate_some(parser, opt, accum, v, sect,
                                            dict(parser.items(sect, raw=True)),
                                            depth + 1, context=context)

--- a/supersettings.py
+++ b/supersettings.py
@@ -51,12 +51,13 @@ class MultiFileConfigParser(configparser.ConfigParser):
     file_name = None
     _DEFAULT_INTERPOLATION = configparser.ExtendedInterpolation()
 
-    def __init__(self, file_name, default_file=None, *args, **kwargs):
+    def __init__(self, file_name, default_file=None, auto_read=True, *args, **kwargs):
         self.file_name = file_name
         self.default_file = default_file
         super(configparser.ConfigParser, self).__init__(*args, **kwargs)
         self.config_files = []
-        self.read_configs()
+        if auto_read:
+            self.read_configs()
 
     def add_config_file(self, path, required=False):
         if path:

--- a/supersettings.py
+++ b/supersettings.py
@@ -23,10 +23,20 @@ import six
 
 if six.PY2:
     from backports import configparser
+    from backports.configparser import NoOptionError, InterpolationSyntaxError, InterpolationDepthError, \
+        MAX_INTERPOLATION_DEPTH, NoSectionError, InterpolationMissingOptionError, _UNSET
 else:
     import configparser
-from backports.configparser import NoOptionError, InterpolationSyntaxError, InterpolationDepthError, \
-    MAX_INTERPOLATION_DEPTH, NoSectionError, InterpolationMissingOptionError, from_none, _UNSET
+    from configparser import NoOptionError, InterpolationSyntaxError, InterpolationDepthError, \
+        MAX_INTERPOLATION_DEPTH, NoSectionError, InterpolationMissingOptionError, _UNSET
+
+
+def from_none(exc):
+    """raise from_none(ValueError('a')) == raise ValueError('a') from None"""
+    exc.__cause__ = None
+    exc.__suppress_context__ = True
+    return exc
+
 
 log = logging.getLogger(__name__)
 

--- a/supersettings.py
+++ b/supersettings.py
@@ -14,10 +14,7 @@ For help with config files please see:
 https://docs.python.org/2/library/configparser.html
 
 """
-try:
-    import ConfigParser as configparser
-except ImportError:
-    import configparser
+from six.moves import configparser
 from collections import OrderedDict
 
 import os
@@ -33,11 +30,16 @@ SECTION_REGEX = re.compile('%\((\w+):(\w+)\)s')
 
 def resolve_string(str, context=None):
     if context:
-        str = str.format(**context)
-        if str.startswith('$'):
+        try:
+            str = str.format(**context)
+        except KeyError:
+            raise
+        if str.startswith('$') or str.startswith('%'):
             name = str[1:]
             return context[name]
     return str
+
+
 
 
 class AttrDict(dict):
@@ -98,6 +100,12 @@ class MultiFileConfigParser(configparser.ConfigParser):
         for cf in config_files:
             self.add_config_file(cf)
 
+    def get(self, section, option, raw=False, vars=None, fallback=None, context=None):
+        v = super(MultiFileConfigParser, self).get(section, option, raw=raw, vars=vars, fallback=fallback)
+        if context:
+            v = resolve_string(v, context)
+        return v
+
     def gettuple(self, section, option, delimiter=','):
         val = self.get(section, option)
         return tuple([v.strip() for v in val.split(delimiter) if v])
@@ -115,9 +123,35 @@ class MultiFileConfigParser(configparser.ConfigParser):
     def getkeys(self, section):
         return self.getdict(section).keys()
 
-    def getsettings(self, section):
-        return OrderedDict([(str(k).upper(), v) for k, v in self.items(section)])
+    def getsettings(self, section, context=None):
+        return OrderedDict(
+            self.items(
+                section,
+                context=context,
+                key_formatter=lambda k, c: resolve_string(str(k).upper()))
+        )
 
-    def items(self, section=configparser._UNSET, raw=False, vars=None, context=None):
+    def items(self, section=configparser._UNSET, raw=False, vars=None, context=None, key_formatter=None,
+              value_formatter=None):
+        key_formatter = key_formatter or resolve_string
+        value_formatter = value_formatter or resolve_string
         items = super(MultiFileConfigParser, self).items(section, raw, vars)
-        return [(resolve_string(k, context), resolve_string(v, context)) for k, v in items]
+        return [(key_formatter(k, context), value_formatter(v, context)) for k, v in items]
+
+    def getenv(self, section, option, key=None, type=str, context=None):
+        """
+        Try and get the option out of os.enviorn and cast it, otherwise return the default (casted)
+        :param section: settings section name
+        :param option: the name of the option
+        :param key: The name of the os.enviorn key.  Defaults to option.
+        :param type: the type to cast it to
+        :return: parsed value
+        """
+        if key is None:
+            key = option
+        value = os.environ.get(key, None)
+        try:
+            return type(value)
+        except TypeError:
+            pass
+        return type(self.get(section, option, context=context))

--- a/supersettings.py
+++ b/supersettings.py
@@ -61,7 +61,8 @@ class MultiFileConfigParser(configparser.ConfigParser):
         {variable} will be formatted as a string out of the context.
     """
     file_name = None
-    _DEFAULT_INTERPOLATION = configparser.ExtendedInterpolation()
+    if hasattr(configparser, 'ExtendedInterpolation'):
+        _DEFAULT_INTERPOLATION = configparser.ExtendedInterpolation()
 
     def __init__(self, file_name, default_file=None, auto_read=True, *args, **kwargs):
         self.file_name = file_name


### PR DESCRIPTION
This allows none for the default file and then you can perform other things as defaults instead of a file. For example, read string instead of file for the base. This will be useful for pulling configs from Consul.
